### PR TITLE
fixing broken link towards list of contributors on github repo

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@
 
 <p>Rdiff-backup has been around for almost 20 years now and has proved to be a very solid solution for backups and it is still unique in its model of unlimited incrementals with no need to space consuming regular full backups.</p>
 
-<p>Current lead developers are Eric Lavarde, Patric Dufresene and Otto Kekäläinen. Full list of core developers available at <a href="https://github.com/rdiff-backup/rdiff-backup/people">rdiff-backup Github page</a> and on the <a href="credits.html">credits page</a>.</p>
+<p>Current lead developers are Eric Lavarde, Patric Dufresene and Otto Kekäläinen. Full list of core developers available at <a href="https://github.com/rdiff-backup/rdiff-backup/graphs/contributors">rdiff-backup Github page</a> and on the <a href="credits.html">credits page</a>.</p>
 
 <p>The original author and maintainer was <strong>Ben Escoto</strong> from 2001 to 2005. Key contributors from 2005 to 2016 were Dean Gaudet, Andrew Ferguson and Edward Ned Harvey. After some hibernation time Sol1 took over the stewardship of rdiff-backup from February 2016 but there were no new releases. In August 2019 <a href="https://www.lavar.de/">Eric Lavarde</a> with the support of Otto Kekäläinen from <a href="https://seravo.com/">Seravo</a> and Patrik Dufresne from <a href="http://www.patrikdufresne.com/en/minarca/">Minarca</a> took over, completed the Python 3 rewrite and finally released rdiff-backup 2.0 in March 2020.</p>
 


### PR DESCRIPTION
Changing the broken link to point to the contributor page of the rdiff-backup repo